### PR TITLE
[JCR Importer] don't remove existing properties

### DIFF
--- a/js/shared/jcr.js
+++ b/js/shared/jcr.js
@@ -405,7 +405,7 @@ const getFilterXml = async (pages, projectUrl) => {
   const pageFilters = jcrPages.reduce((acc, page) => {
     const propertiesFilter = page.pageProperties.map((prop) => `<include pattern='${page.jcrPath}/jcr:content/${prop}' matchProperties='true'/>`).join('\n');
     const childrenFilter = page.pageContentChildren.map((child) => `<filter root='${page.jcrPath}/jcr:content/${child}'/>`).join('\n');
-    return `${acc}<filter root='${page.jcrPath}/jcr:content'>\n${propertiesFilter}\n</filter>${childrenFilter}\n`;
+    return `${acc}<filter root='${page.jcrPath}/jcr:content'>\n${propertiesFilter}\n</filter>\n${childrenFilter}\n`;
   }, '');
 
   const jcrAssetPaths = await getJcrAssetPaths(pages, projectUrl);

--- a/js/shared/jcr.js
+++ b/js/shared/jcr.js
@@ -20,7 +20,6 @@ const CUSTOM_SITE_NAME = CUSTOM_SITE_NAME_DEFAULT;
 // you can disable this by setting this to false
 const ADD_ASSET_TO_PACKAGE_DEFAULT = true;
 const ADD_ASSET_TO_PACKAGE = ADD_ASSET_TO_PACKAGE_DEFAULT;
-const NON_OVERWRITTEN_PAGE_PROPERTIES = ['jcr:primaryType', 'jcr:title', 'jcr:description'];
 
 // cache for pages and assets
 let jcrPages = [];
@@ -278,7 +277,7 @@ const getPageProperties = (xml) => {
   const localName = 'content';
   const jcrContent = doc.getElementsByTagNameNS(namespaceURI, localName)[0];
   // eslint-disable-next-line max-len
-  return jcrContent ? jcrContent.getAttributeNames().filter((name) => !NON_OVERWRITTEN_PAGE_PROPERTIES.includes(name)) : [];
+  return jcrContent ? jcrContent.getAttributeNames() : [];
 };
 
 const getPageContentChildren = (xml) => {

--- a/test/jcr.test.js
+++ b/test/jcr.test.js
@@ -105,6 +105,15 @@ const testData = {
       expected: {
         jcrPath: '/content/repo/1/2/page',
         contentXmlPath: 'jcr_root/content/repo/1/2/page/.content.xml',
+        pageContentChildren: [
+          'root',
+        ],
+        pageProperties: [
+          'cq:template',
+          'jcr:primaryType',
+          'jcr:title',
+          'sling:resourceType',
+        ],
       },
     },
     {
@@ -159,6 +168,15 @@ const testData = {
       expected: {
         jcrPath: '/content/repo/3/4/page',
         contentXmlPath: 'jcr_root/content/repo/3/4/page/.content.xml',
+        pageContentChildren: [
+          'root',
+        ],
+        pageProperties: [
+          'cq:template',
+          'jcr:primaryType',
+          'jcr:title',
+          'sling:resourceType',
+        ],
       },
     },
   ],
@@ -237,6 +255,8 @@ describe('JCR Importer', () => {
       jcrPath: page.expected.jcrPath,
       contentXmlPath: page.expected.contentXmlPath,
       url: page.url,
+      pageContentChildren: page.expected.pageContentChildren,
+      pageProperties: page.expected.pageProperties,
     }));
     const actualPages = await getJcrPages(testPages, testData.projectUrl);
     assert.deepEqual(actualPages, expectedPages, 'JCR pages are not as expected');

--- a/test/jcr.test.js
+++ b/test/jcr.test.js
@@ -105,15 +105,6 @@ const testData = {
       expected: {
         jcrPath: '/content/repo/1/2/page',
         contentXmlPath: 'jcr_root/content/repo/1/2/page/.content.xml',
-        pageContentChildren: [
-          'root',
-        ],
-        pageProperties: [
-          'cq:template',
-          'jcr:primaryType',
-          'jcr:title',
-          'sling:resourceType',
-        ],
       },
     },
     {
@@ -168,15 +159,6 @@ const testData = {
       expected: {
         jcrPath: '/content/repo/3/4/page',
         contentXmlPath: 'jcr_root/content/repo/3/4/page/.content.xml',
-        pageContentChildren: [
-          'root',
-        ],
-        pageProperties: [
-          'cq:template',
-          'jcr:primaryType',
-          'jcr:title',
-          'sling:resourceType',
-        ],
       },
     },
   ],
@@ -255,8 +237,6 @@ describe('JCR Importer', () => {
       jcrPath: page.expected.jcrPath,
       contentXmlPath: page.expected.contentXmlPath,
       url: page.url,
-      pageContentChildren: page.expected.pageContentChildren,
-      pageProperties: page.expected.pageProperties,
     }));
     const actualPages = await getJcrPages(testPages, testData.projectUrl);
     assert.deepEqual(actualPages, expectedPages, 'JCR pages are not as expected');

--- a/test/jcr.test.js
+++ b/test/jcr.test.js
@@ -110,6 +110,8 @@ const testData = {
         ],
         pageProperties: [
           'cq:template',
+          'jcr:primaryType',
+          'jcr:title',
           'sling:resourceType',
         ],
       },
@@ -171,6 +173,8 @@ const testData = {
         ],
         pageProperties: [
           'cq:template',
+          'jcr:primaryType',
+          'jcr:title',
           'sling:resourceType',
         ],
       },

--- a/test/jcr.test.js
+++ b/test/jcr.test.js
@@ -105,6 +105,13 @@ const testData = {
       expected: {
         jcrPath: '/content/repo/1/2/page',
         contentXmlPath: 'jcr_root/content/repo/1/2/page/.content.xml',
+        pageContentChildren: [
+          'root',
+        ],
+        pageProperties: [
+          'cq:template',
+          'sling:resourceType',
+        ],
       },
     },
     {
@@ -159,6 +166,13 @@ const testData = {
       expected: {
         jcrPath: '/content/repo/3/4/page',
         contentXmlPath: 'jcr_root/content/repo/3/4/page/.content.xml',
+        pageContentChildren: [
+          'root',
+        ],
+        pageProperties: [
+          'cq:template',
+          'sling:resourceType',
+        ],
       },
     },
   ],
@@ -237,6 +251,8 @@ describe('JCR Importer', () => {
       jcrPath: page.expected.jcrPath,
       contentXmlPath: page.expected.contentXmlPath,
       url: page.url,
+      pageContentChildren: page.expected.pageContentChildren,
+      pageProperties: page.expected.pageProperties,
     }));
     const actualPages = await getJcrPages(testPages, testData.projectUrl);
     assert.deepEqual(actualPages, expectedPages, 'JCR pages are not as expected');


### PR DESCRIPTION
- update page properties which are defined in the package
- keep existing page properties which are not defined in the package
- create intermediary page nodes if they are not available in the repo, with `cq:Page` and `cq:PageContent` properties 
